### PR TITLE
Build 0.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - vega_datasets.tests
 
 about:
-  home: http://github.com/altair-viz/vega_datasets/
+  home: https://github.com/altair-viz/vega_datasets/
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-dep --no-build-isolation -vv
 
 requirements:
   host:
@@ -32,7 +32,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: "A Python package for offline access to Vega datasets"
+  summary: A Python package for offline access to Vega datasets
   description: |
     A Python package for offline access to Vega datasets available at
     https://github.com/vega/vega-datasets.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,10 @@ requirements:
     - pandas
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - vega_datasets
     - vega_datasets.tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-dep --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,8 @@ about:
     - wherever dataset size and/or license constraints make it possible,
       bundle the dataset with the package so that datasets can be loaded in
       the absence of a web connection.
-  doc_url: http://github.com/altair-viz/vega_datasets/
-  dev_url: http://github.com/altair-viz/vega_datasets/
+  doc_url: https://github.com/altair-viz/vega_datasets/
+  dev_url: https://github.com/altair-viz/vega_datasets/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[Upstream Repo](http://github.com/altair-viz/vega_datasets/)

`great-expectations` <- `altair 4.2.2` <- `vega_datasets 0.9` (Required for `altair` test suite)

This was updated a couple years ago, but never uploaded to defaults. 

- Dropped `noarch: python`
- Added `--no-build-isolation`